### PR TITLE
Simplify filename and handle null external Ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ The plugin requires a configuration file. Here is an example:
       "query": "SELECT Name, FieldOne__c, FieldTwo__c, Migration_Id__c FROM ObjectOne__c",
       "externalid": "Migration_ID__c",
       "directory": "objectOne",
-      "filename": "Migration_ID__c",
       "cleanupFields": [],
       "hasRecordTypes": false
     },
@@ -103,7 +102,6 @@ The plugin requires a configuration file. Here is an example:
       "query": "SELECT Name, ObjectOne__r.Migration_Id__c, Migration_Id__c, FieldOne__c, RecordType.DeveloperName FROM ObjectTwo__c",
       "externalid": "Migration_Id__c",
       "directory": "objectTwo",
-      "filename": "Migration_Id__c",
       "cleanupFields": ["ObjectOne__r"],
       "hasRecordTypes": true,
       "enableMultiThreading": true
@@ -123,9 +121,8 @@ The plugin requires a configuration file. Here is an example:
 | `allObjects`                   | An array with all of the objects (the order they are specified is the order they are processed)                                                                                                                                                                                                                                        |
 | `objects`                      | An array of configuration for each object (there should be one entry per entry in the `allObjects` array)                                                                                                                                                                                                                              |
 | `objects:query`                | The query that is performed to `export` the data from Salesforce                                                                                                                                                                                                                                                                       |
-| `objects:externalId`           | The external id field for this object (API Name)                                                                                                                                                                                                                                                                                       |
-| `objects:directory`            | The name of the directory the extracted data will be stored in. It is a relevant path from where the export command is executed of `data/directory`                                                                                                                                                                                    |
-| `objects:filename`             | The field used to determine the filename (must be unique)                                                                                                                                                                                                                                                                              |
+| `objects:externalId`           | The external id field for this object (API Name). This will also be used as the file name for the extracted json files.                                                                                                                                                                                                                |
+| `objects:directory`            | The name of the directory the extracted data will be stored in. It is a relevant path from where the export command is executed of `data/directory`                                                                                                                                                                                    |  |
 | `objects:cleanupFields`        | Any fields fetched from a parent lookup that may be blank should be specified here. For example, if you are retrieving the Migration Id of a parent (`ObjectOne__r.Migration_Id__c`) and this lookup _could_ be blank, then `ObjectOne__r` should be added to this array as the plugin cannot handle null values on parent references. |
 | `objects:hasRecordTypes`       | Whether dynamic record type Ids need to be handled or not (if true, ensure the `RecordType.DeveloperName` is in the query)                                                                                                                                                                                                             |
 | `objects:enableMultiThreading` | The payloads can be imported into this object in parallel (instead of one after the other).                                                                                                                                                                                                                                            |

--- a/src/commands/bourne/export.ts
+++ b/src/commands/bourne/export.ts
@@ -1,7 +1,6 @@
-import { flags, SfdxCommand } from "@salesforce/command";
+import { flags, SfdxCommand, core } from "@salesforce/command";
 import { Helper } from "../../helper/Helper";
 import { AnyJson } from "@salesforce/ts-types";
-import { core } from "@salesforce/command";
 import * as _ from "lodash";
 
 export default class Export extends SfdxCommand {
@@ -44,7 +43,13 @@ export default class Export extends SfdxCommand {
     records.forEach(record => {
       Helper.removeField(record, "attributes");
       this.removeNullFields(record, sObjectName);
-      let fileName = record[Export.config.objects[sObjectName].externalid];
+      let externalIdField = Export.config.objects[sObjectName].externalid;
+      if (!record.hasOwnProperty(externalIdField)) {
+        throw new core.SfdxError(
+          "The External Id provided on the configuration file does not exist on the extracted record(s). Please ensure it is included in the object's query."
+        );
+      }
+      let fileName = record[externalIdField];
       if (fileName == null) {
         throw new core.SfdxError(
           "There are records without External Ids. Ensure all records that are extracted have a value for the field specified as the External Id."

--- a/src/commands/bourne/export.ts
+++ b/src/commands/bourne/export.ts
@@ -40,15 +40,16 @@ export default class Export extends SfdxCommand {
   }
 
   private exportRecordsToDir(records, sObjectName, dirPath) {
+    let externalIdField = Export.config.objects[sObjectName].externalid;
+    if (records.length > 0 && !records[0].hasOwnProperty(externalIdField)) {
+      throw new core.SfdxError(
+        "The External Id provided on the configuration file does not exist on the extracted record(s). Please ensure it is included in the object's query."
+      );
+    }
+
     records.forEach(record => {
       Helper.removeField(record, "attributes");
       this.removeNullFields(record, sObjectName);
-      let externalIdField = Export.config.objects[sObjectName].externalid;
-      if (!record.hasOwnProperty(externalIdField)) {
-        throw new core.SfdxError(
-          "The External Id provided on the configuration file does not exist on the extracted record(s). Please ensure it is included in the object's query."
-        );
-      }
       let fileName = record[externalIdField];
       if (fileName == null) {
         throw new core.SfdxError(

--- a/src/commands/bourne/export.ts
+++ b/src/commands/bourne/export.ts
@@ -1,6 +1,7 @@
 import { flags, SfdxCommand } from "@salesforce/command";
 import { Helper } from "../../helper/Helper";
 import { AnyJson } from "@salesforce/ts-types";
+import { core } from "@salesforce/command";
 import * as _ from "lodash";
 
 export default class Export extends SfdxCommand {
@@ -43,23 +44,23 @@ export default class Export extends SfdxCommand {
     records.forEach(record => {
       Helper.removeField(record, "attributes");
       this.removeNullFields(record, sObjectName);
-      let filename =
-        dirPath +
-        "/" +
-        record[Export.config.objects[sObjectName].filename].replace(
-          /\s+/g,
-          "-"
-        ) +
-        ".json";
-      Helper.fs.writeFile(
-        filename,
-        JSON.stringify(record, undefined, 2),
-        function(err) {
-          if (err) {
-            throw err;
+      let fileName = record[Export.config.objects[sObjectName].externalid];
+      if (fileName == null) {
+        throw new core.SfdxError(
+          "There are records without External Ids. Ensure all records that are extracted have a value for the field specified as the External Id."
+        );
+      } else {
+        fileName = dirPath + "/" + fileName.replace(/\s+/g, "-") + ".json";
+        Helper.fs.writeFile(
+          fileName,
+          JSON.stringify(record, undefined, 2),
+          function(err) {
+            if (err) {
+              throw err;
+            }
           }
-        }
-      );
+        );
+      }
     });
   }
 


### PR DESCRIPTION
#### What changes are included in this PR?
- Changed the export script to use the `External Id` field as the filename
- Added error handling to determine when an extracted field is null
- Updated the documentation to reflect the changes

Addresses issue #2 